### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -7,6 +7,9 @@ on:
         required: true
         default: 'b81c174021e76dfd9d62aee830f1143eb0a38280'
 
+permissions:
+  contents: write
+
 jobs:
   selective-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Ero-gamer/Kotatsu-Next/security/code-scanning/28](https://github.com/Ero-gamer/Kotatsu-Next/security/code-scanning/28)

Add an explicit `permissions` block to the workflow (or the specific job) with the least privileges needed for current behavior.

Best fix here, without changing functionality:
- Add a workflow-level `permissions` block right after `on:`/inputs section and before `jobs:`.
- Set:
  - `contents: write` (required for `git push origin dev`)
- Do not add broader scopes since this workflow does not show use of issues, PR, packages, etc.

File to edit:
- `.github/workflows/cherry-pick.yml`
- Insert `permissions:` between lines 9 and 10 (before `jobs:`).

No imports/dependencies/methods are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
